### PR TITLE
Add note about deleteUser to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ To run the tests you'll need to set the following environment variables:
 	1. HUE_TEST_USERNAME (You can obtain a whitelisted username via examples/discover.go)
 	1. HUE_TEST_HOSTNAME (Your hue hub's hostname or IP address)
 
+important note
+--------------
+As of API `1.31`, Philips/Hue has disabled the `deleteUser` function, and it will always return the error `unauthorized user`.
+
+To delete an app from your bridge, you must login to https://account.meethue.com/apps and manually delete using the website.
+
 bugs and contribution
 ---------------------
 Please feel free to reach out. Issues and PR's are always welcome!
+
+


### PR DESCRIPTION
FYI as of API version `1.31` the API no longer allows deleting users. It must be done manually on the Hue developer portal.

This PR just adds a note to the readme so other developers don't get stuck wondering why the `deleteUser` function isn't working for them.

This issue details the findings: https://github.com/Hyrules/WinHue/issues/231